### PR TITLE
Add option to update unchanged states

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -908,6 +908,7 @@
                 holdingRegsOffset:  settings.params.holdingRegsOffset || 40001,
                 showAliases:        (settings.params.showAliases === undefined) ? true : settings.params.showAliases,
                 directAddresses:    settings.params.directAddresses || false,
+                alwaysUpdate:       settings.params.alwaysUpdate    || false,
                 doNotRoundAddressToWord:    settings.params.doNotRoundAddressToWord || false,
                 comName:       settings.params.comName       || '',
                 type:          settings.params.type          || 'tcp',
@@ -921,6 +922,7 @@
         };
         data.params.showAliases     = (data.params.showAliases     === 'true' || data.params.showAliases     === true);
         data.params.directAddresses = (data.params.directAddresses === 'true' || data.params.directAddresses === true);
+        data.params.alwaysUpdate    = (data.params.alwaysUpdate    === 'true' || data.params.alwaysUpdate    === true);
 
         onChange = onchange;
 
@@ -1293,12 +1295,16 @@
             <tr>
                 <td><label class="translate" for="modbus_maxBlock">Max read request length:</label></td>
                 <td style="text-align: center"><input style="margin-right: 5px;text-align: right" type="text" class="modbus-params" id="modbus_maxBlock"></td>
-                <td calss="translate">registers</td>
+                <td class="translate">registers</td>
             </tr>
             <tr>
                 <td><label class="translate" for="modbus_maxBoolBlock">Max read request length (booleans):</label></td>
                 <td style="text-align: center"><input style="margin-right: 5px;text-align: right" type="text" class="modbus-params" id="modbus_maxBoolBlock"></td>
-                <td calss="translate">registers</td>
+                <td class="translate">registers</td>
+            </tr>
+            <tr>
+                <td><label class="translate" for="modbus_alwaysUpdate">Update unchanged states:</label></td>
+                <td><input style="margin-right: 5px;text-align: right" class="modbus-params" type="checkbox" id="modbus_alwaysUpdate"/></td>
             </tr>
             <tr>
                 <td colspan="3" style="height: 10px"></td>

--- a/lib/master.js
+++ b/lib/master.js
@@ -111,7 +111,7 @@ function Master(options, adapter) {
                         let id = regs.config[n].id;
                         let val = response.data[regs.config[n].address - regBlock.start];
 
-                        if (ackObjects[id] === undefined || ackObjects[id].val !== val) {
+                        if (options.config.alwaysUpdate || ackObjects[id] === undefined || ackObjects[id].val !== val) {
                             ackObjects[id] = {val: val};
                             adapter.setState(id, !!val, true, err => {
                                 // analyse if the state could be set (because of permissions)
@@ -167,7 +167,7 @@ function Master(options, adapter) {
                             val = val * regs.config[n].factor + regs.config[n].offset;
                             val = Math.round(val * options.config.round) / options.config.round;
                         }
-                        if (ackObjects[id] === undefined || ackObjects[id].val !== val) {
+                        if (options.config.alwaysUpdate || ackObjects[id] === undefined || ackObjects[id].val !== val) {
                             ackObjects[id] = {val: val};
                             adapter.setState(id, val, true, err => {
                                 // analyse if the state could be set (because of permissions)

--- a/main.js
+++ b/main.js
@@ -329,6 +329,7 @@ function prepareConfig(config) {
         config: {
             type:               params.type || 'tcp',
             slave:              params.slave,
+            alwaysUpdate:       params.alwaysUpdate,
             round:              parseInt(params.round, 10) || 0,
             timeout:            parseInt(params.timeout, 10) || 5000,
             defaultDeviceId:   (params.deviceId === undefined || params.deviceId === null) ? 1 : (parseInt(params.deviceId, 10) || 0),


### PR DESCRIPTION
This is useful with "unchanged" logging and no explicit interval, so values get always saved when they are fetched.

I am unsure if I included the check in all needed locations. - Works for holding registers...

