### PR TITLE
fixed handling of data type stringle  - String (Little Endian, Zero-end); added options for ID

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -902,13 +902,15 @@
                 round:      settings.params.round || 2,
                 maxBlock:   settings.params.maxBlock || 100,
                 maxBoolBlock:   settings.params.maxBoolBlock || 128,
-                disInputsOffset:    settings.params.disInputsOffset   || 10001,
-                coilsOffset:        settings.params.coilsOffset       || 1,
-                inputRegsOffset:    settings.params.inputRegsOffset   || 30001,
-                holdingRegsOffset:  settings.params.holdingRegsOffset || 40001,
-                showAliases:        (settings.params.showAliases === undefined) ? true : settings.params.showAliases,
-                directAddresses:    settings.params.directAddresses || false,
-                alwaysUpdate:       settings.params.alwaysUpdate    || false,
+                disInputsOffset:      settings.params.disInputsOffset   || 10001,
+                coilsOffset:          settings.params.coilsOffset       || 1,
+                inputRegsOffset:      settings.params.inputRegsOffset   || 30001,
+                holdingRegsOffset:    settings.params.holdingRegsOffset || 40001,
+                showAliases:          (settings.params.showAliases === undefined) ? true : settings.params.showAliases,
+                directAddresses:      settings.params.directAddresses     || false,
+                alwaysUpdate:         settings.params.alwaysUpdate        || false,
+                doNotIncludeAdrInId:  settings.params.doNotIncludeAdrInId || false,
+                preserveDotsInId:     settings.params.preserveDotsInId    || false,
                 doNotRoundAddressToWord:    settings.params.doNotRoundAddressToWord || false,
                 comName:       settings.params.comName       || '',
                 type:          settings.params.type          || 'tcp',
@@ -920,9 +922,11 @@
                 multiDeviceId: settings.params.multiDeviceId || false
             }
         };
-        data.params.showAliases     = (data.params.showAliases     === 'true' || data.params.showAliases     === true);
-        data.params.directAddresses = (data.params.directAddresses === 'true' || data.params.directAddresses === true);
-        data.params.alwaysUpdate    = (data.params.alwaysUpdate    === 'true' || data.params.alwaysUpdate    === true);
+        data.params.showAliases         = (data.params.showAliases          === 'true' || data.params.showAliases           === true);
+        data.params.directAddresses     = (data.params.directAddresses      === 'true' || data.params.directAddresses       === true);
+        data.params.alwaysUpdate        = (data.params.alwaysUpdate         === 'true' || data.params.alwaysUpdate          === true);
+        data.params.doNotIncludeAdrInId = (data.params.doNotIncludeAdrInId  === 'true' || data.params.doNotIncludeAdrInId   === true);
+        data.params.preserveDotsInId    = (data.params.preserveDotsInId     === 'true' || data.params.preserveDotsInId      === true);
 
         onChange = onchange;
 
@@ -1305,6 +1309,14 @@
             <tr>
                 <td><label class="translate" for="modbus_alwaysUpdate">Update unchanged states:</label></td>
                 <td><input style="margin-right: 5px;text-align: right" class="modbus-params" type="checkbox" id="modbus_alwaysUpdate"/></td>
+            </tr>
+            <tr>
+                <td><label class="translate" for="modbus_doNotIncludeAdrInId">do not include address in ID:</label></td>
+                <td><input style="margin-right: 5px;text-align: right" class="modbus-params" type="checkbox" id="modbus_doNotIncludeAdrInId"/></td>
+            </tr>
+            <tr>
+                <td><label class="translate" for="modbus_preserveDotsInId">preserve dots in ID:</label></td>
+                <td><input style="margin-right: 5px;text-align: right" class="modbus-params" type="checkbox" id="modbus_preserveDotsInId"/></td>
             </tr>
             <tr>
                 <td colspan="3" style="height: 10px"></td>

--- a/io-package.json
+++ b/io-package.json
@@ -162,6 +162,8 @@
             "holdingRegsOffset": 40001,
             "showAliases": true,
             "directAddresses": false,
+            "doNotIncludeAdrInId": false,
+            "preserveDotsInId": false,
             "round": 2,
             "doNotRoundAddressToWord": false
         },

--- a/lib/common.js
+++ b/lib/common.js
@@ -118,7 +118,7 @@ function extractValue(type, len, buffer, offset) {
                 if (buffer[offset * 2 + __len + 1]) {
                     str += String.fromCharCode(buffer[offset * 2 + __len + 1]);
 
-                    if (str += String.fromCharCode(buffer[offset * 2 + __len])) {
+                    if (buffer[offset * 2 + __len]) {
                         str += String.fromCharCode(buffer[offset * 2 + __len]);
                     } else {
                         break;
@@ -128,7 +128,6 @@ function extractValue(type, len, buffer, offset) {
                 }
                 __len += 2;
             }
-
             return str;
         default:
             throw new Error('Invalid type: ' + type);
@@ -306,7 +305,7 @@ function writeValue(type, value, len) {
             if (__len % 2) __len++;
             buffer = new Buffer(__len);
             for (let b = 0; b < (__len >> 1); b++) {
-                buffer.writeInt16LE((value.charCodeAt(b * 2) << 8) | value.charCodeAt(b * 2 + 1));
+                buffer.writeInt16LE((value.charCodeAt(b * 2) << 8) | value.charCodeAt(b * 2 + 1), b << 1);
                 if (b * 2 + 2 >= buffer.length) {
                     break;
                 }

--- a/lib/master.js
+++ b/lib/master.js
@@ -163,7 +163,7 @@ function Master(options, adapter) {
                     for (let n = regBlock.startIndex; n < regBlock.endIndex; n++) {
                         let id = regs.config[n].id;
                         let val = common.extractValue(regs.config[n].type, regs.config[n].len, response.payload, regs.config[n].address - regBlock.start);
-                        if (regs.config[n].type !== 'string') {
+                        if ((regs.config[n].type !== 'string') && (regs.config[n].type !== 'stringle')) {
                             val = val * regs.config[n].factor + regs.config[n].offset;
                             val = Math.round(val * options.config.round) / options.config.round;
                         }
@@ -391,7 +391,7 @@ function Master(options, adapter) {
                     objects[id].native.type === 'doublele' || objects[id].native.type === 'doublebe' || objects[id].native.type === 'floatsb';
             }
 
-            if (objects[id].native.type !== 'string') {
+            if (objects[id].native.type !== 'string' && objects[id].native.type !== 'stringle') {
                 val = parseFloat(val);
                 val = (val - objects[id].native.offset) / objects[id].native.factor;
                 if (!objects[id].native.float) val = Math.round(val);

--- a/main.js
+++ b/main.js
@@ -334,6 +334,8 @@ function prepareConfig(config) {
             round:              parseInt(params.round, 10) || 0,
             timeout:            parseInt(params.timeout, 10) || 5000,
             defaultDeviceId:   (params.deviceId === undefined || params.deviceId === null) ? 1 : (parseInt(params.deviceId, 10) || 0),
+            doNotIncludeAdrInId: params.doNotIncludeAdrInId,
+            preserveDotsInId:   params.preserveDotsInId,
         },
         devices: {}
     };
@@ -591,9 +593,21 @@ function iterateAddresses(isBools, deviceId, result, regName, regType, localOpti
             if (localOptions.showAliases) {
                 config[i].id += address2alias(regType, address, localOptions.directAddresses, result.offset);
             } else {
+              // add address if not disabled or name not empty
+              if (!localOptions.doNotIncludeAdrInId || !config[i].name) {
                 config[i].id += address;
+                if (localOptions.preserveDotsInId) {
+                  config[i].id += '_';
+                }
+              }
             }
-            config[i].id += (config[i].name ? '_' + (config[i].name.replace('.', '_').replace(' ', '_')) : '');
+            if (localOptions.preserveDotsInId) {
+              // preserve dots in name and add to ID
+              config[i].id += (config[i].name ? (config[i].name.replace(' ', '_')) : '');
+            } else {
+              // replace dots by underlines and add to ID
+              config[i].id += (config[i].name ? '_' + (config[i].name.replace('.', '_').replace(' ', '_')) : '');
+            }
 
             // collect cyclic write registers
             if (config[i].cw) {
@@ -676,7 +690,9 @@ function parseConfig(callback) {
         doNotRoundAddressToWord:    (params.doNotRoundAddressToWord === true || params.doNotRoundAddressToWord === 'true'),
         directAddresses:            (params.directAddresses         === true || params.directAddresses         === 'true'),
         maxBlock:                   options.config.maxBlock,
-        maxBoolBlock:               options.config.maxBoolBlock
+        maxBoolBlock:               options.config.maxBoolBlock,
+        doNotIncludeAdrInId:        (params.doNotIncludeAdrInId     === true || params.doNotIncludeAdrInId     === 'true'),
+        preserveDotsInId:           (params.preserveDotsInId        === true || params.preserveDotsInId        === 'true'),
     };
 
     adapter.getForeignObjects(adapter.namespace + '.*', (err, list) => {

--- a/main.js
+++ b/main.js
@@ -237,7 +237,8 @@ const type_items_len = {
     'floatsb':    2,
     'doublebe':   4,
     'doublele':   4,
-    'string':     0
+    'string':     0,
+    'stringle':   0,
 };
 
 const _rmap = {
@@ -487,7 +488,7 @@ function checkObjects(options, regType, regName, regFullName, tasks, newObjects)
                 name:    regs[i].description,
                 role:    regs[i].role,
                 type:    regType === 'coils' || regType === 'disInputs' ? 'boolean' :
-                    ((regs[i].type === 'string' || regs[i].type === 'string') ? 'string' : 'number'),
+                    ((regs[i].type === 'string' || regs[i].type === 'stringle') ? 'string' : 'number'),
                 read:    true,
                 write:   regType === 'coils' || regType === 'holdingRegs',
                 def:     regType === 'coils' || regType === 'disInputs' ? false : 0
@@ -571,7 +572,7 @@ function iterateAddresses(isBools, deviceId, result, regName, regType, localOpti
                 config[i].type   = config[i].type || 'uint16be';
                 config[i].offset = parseFloat(config[i].offset) || 0;
                 config[i].factor = parseFloat(config[i].factor) || 1;
-                if (config[i].type === 'string') {
+                if ((config[i].type === 'string') || (config[i].type === 'stringle')) {
                     config[i].len = parseInt(config[i].len, 10) || 1;
                 } else {
                     config[i].len = type_items_len[config[i].type];


### PR DESCRIPTION
Fixed handling of data type stringle  - String (Little Endian, Zero-end).

Added two options for the generation of the object ID's:
- preserve dots in name to keep the hierarchy of structs
- omit address to get stable ID's for changing addresses

Tested in master mode while communicating with a Wago 750-880 PLC.