### PR TITLE
Funktion ergänzt für Formeln und dynamische Skalierungsfaktoren 

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,46 @@ If slave does not support "write multiple registers" command, you can activate i
 ### Write interval
 Delay between two write requests in ms. Default 0.
 
+## Parameters for single address line in config
+### Address
+Modbus address to read
+### Slave ID
+In case there are multiple slaves, then this is the id if not the default one which is given in global config
+### Name
+This is the name for the Parameter
+### Description
+Parameter description 
+### Unit
+Unit of the Parameter
+### Type
+Datatype to read from Bus. For details about the possible datatypes see section Data types
+### Length
+Length of parameter. For the most parameters this is determined based on the data type, but for Strings this defines the lenght in Bytes / characters
+### Factor
+This factor is used to multiply the read value from Bus for static scaling. So the calculation looks like following val = x * Factor + Offset
+### Offset
+This offset is added to the read value after above multiplication. So the calculation looks like following val = x * Factor + Offset
+### Formula
+This field can be used for advanced calculations if Factor and Offset is not sufficient. If this field is set, then the Factor and Offset field is ignored.
+The Formula is executed by the eval() function. Therefore all common functions are supported. Especially the Math functions. The formula must comply with Javascript syntax, therefore also take care about uper and lower cases.
+
+In the formula, "x" has to be used for the read value from Modbus. E.g. "x * Math.pow(10,sf['40065']);"
+
+If the formula cannot evaluated during runtime, then the Adapter writes a warning message to the log.
+
+### Role
+IOBroker role to assign
+### Room
+IOBroker room to assign
+### Poll
+If activated, the values are polled in predefined interval from slave.
+### WP
+Write pulse
+### CW
+Cyclic write
+### SF
+Use value as scaling factor. This is needed to used dynamic scaling factors which are on some systems provided through values on interface. If a value is marked with this flac, then the value will stored into a variable with following naming convention: sf['Modbus_address']. This variable can then later used in any formula for other parameters. E.g. following formula can set: "(x * sf['40065']) + 50;"
+
 ## Data types
 
 - uint16be - Unsigned 16 bit (Big Endian): AABB => AABB

--- a/admin/index.html
+++ b/admin/index.html
@@ -255,7 +255,7 @@
             if (!data.params.slave) {
                 text += delimiter + 'cw';
             }
-            text += 'sf' + delimiter;
+            text += delimiter + 'isScale';
         }
         text += '\n';
 
@@ -288,7 +288,7 @@
                 if (!data.params.slave) {
                     text += (data[id][i].cw   ? 'true' : 'false') + delimiter;
                 }
-                text += (data[id][i].isScaleFactor   ? 'true' : 'false') + delimiter;
+                text += (data[id][i].isScale   ? 'true' : 'false') + delimiter;
             }
             text += '\n';
         }
@@ -316,7 +316,7 @@
         var isAliases = $('#modbus_showAliases').prop('checked');
         var mapping;
         if (id !== 'coils' && id !== 'disInputs') {
-            mapping = ['deviceId', 'address', 'name', 'description', 'unit', 'type', 'len', 'factor', 'offset', 'role', 'room','formula','isScaleFactor'];
+            mapping = ['deviceId', 'address', 'name', 'description', 'unit', 'type', 'len', 'factor', 'offset', 'role', 'room','formula','isScale'];
         } else {
             mapping = ['deviceId', 'address', 'name', 'description', 'role', 'room'];
         }
@@ -365,9 +365,9 @@
                 } else if (mapping[m] === 'cw') {
                     obj[mapping[m]] = val || '';
                     obj.cw = (obj.cw.toLowerCase() === 'true' || obj.cw === '1' || obj.cw === '+');
-                } else if (mapping[m] === 'isScaleFactor') {
+                } else if (mapping[m] === 'isScale') {
                     obj[mapping[m]] = val || '';
-                    obj.isScaleFactor = (obj.isScaleFactor.toLowerCase() === 'true' || obj.isScaleFactor === '1' || obj.isScaleFactor === '+');
+                    obj.isScale = (obj.isScale.toLowerCase() === 'true' || obj.isScale === '1' || obj.isScale === '+');
                 } else {
                     obj[mapping[m]] = val || '';
                 }
@@ -500,23 +500,23 @@
                     }
                 }
                 var fields = [
-                    {name: '_address'   , title:  _('Address'),       type: 'text',       width: '80px', sorter: 'number'},
+                    {name: '_address'   , title:  _('Address'),       type: 'text',       width: '60px', sorter: 'number'},
                     {name: 'deviceId'   , title:  _('deviceId'),      type: 'text',       width: '60px',  sorter: 'number'},
                     {name: 'name'       , title:  _('Name'),          type: 'text',       width: '*'},
                     {name: 'description', title:  _('Description'),   type: 'text',       width: '*'},
                     {name: 'unit'       , title:  _('Unit'),          type: 'text',       width: '50px'},
-                    {name: 'type'       , title:  _('Type'),          type: 'select',     width: '150px', items: typeItems,  valueField: 'value', textField: 'text'},
+                    {name: 'type'       , title:  _('Type'),          type: 'select',     width: '*', items: typeItems,  valueField: 'value', textField: 'text'},
                     {name: 'len'        , title:  _('Length'),        type: 'text',       width: '50px'},
                     {name: 'factor'     , title:  _('Factor'),        type: 'text',       width: '50px'},
                     {name: 'offset'     , title:  _('Offset'),        type: 'text',       width: '50px'},
-                    {name: 'formula'     , title:  _('formula'),      type: 'text',       width: '100px'},
-                    {name: 'role'       , title:  _('Role'),          type: 'select',     width: '70px', items: roleItems,  valueField: 'value', textField: 'text'},
-                    {name: 'room'       , title:  _('Room'),          type: 'select',     width: '70px', items: roomsItems, valueField: 'value', textField: 'text'},
+                    {name: 'formula'    , title:  _('formula'),      type: 'text',       width: '*'},
+                    {name: 'role'       , title:  _('Role'),          type: 'select',     width: '60px', items: roleItems,  valueField: 'value', textField: 'text'},
+                    {name: 'room'       , title:  _('Room'),          type: 'select',     width: '60px', items: roomsItems, valueField: 'value', textField: 'text'},
                     {name: 'poll'       , title:  _('poll'),          type: 'checkbox',   width: '30px'},
                     {name: 'wp'         , title:  _('WP'),            type: 'checkbox',   width: '30px'},
                     {name: 'cw'         , title:  _('CW'),            type: 'checkbox',   width: '30px'},
-                    {name: 'isScaleFactor', title:  _('SF'),          type: 'checkbox',   width: '30px'},
-                    {                                                 type: 'control',    width: '80px'}
+                    {name: 'isScale'    , title:  _('SF'),            type: 'checkbox',   width: '30px'},
+                    {                                                 type: 'control',    width: '60px'}
                 ];
                 if (_id === 'modbus_disInputs' || _id === 'modbus_inputRegs') {
                     fields.splice(11, 3);
@@ -682,7 +682,7 @@
                             obj.item.factor   = data[id][data[id].length - 1].factor;
                             obj.item.offset   = data[id][data[id].length - 1].offset;
                             obj.item.deviceId = data[id][data[id].length - 1].deviceId;
-                            obj.item.isScaleFactor = data[id][data[id].length - 1].isScaleFactor;
+                            obj.item.isScale = data[id][data[id].length - 1].isScale;
                             obj.item.formula = data[id][data[id].length - 1].formula;
 
                             var len;

--- a/admin/index.html
+++ b/admin/index.html
@@ -244,6 +244,7 @@
             text += 'len'    + delimiter;
             text += 'factor' + delimiter;
             text += 'offset' + delimiter;
+            text += 'formula'+ delimiter;
         }
         text += 'role' + delimiter +
                 'room' + delimiter;
@@ -254,6 +255,7 @@
             if (!data.params.slave) {
                 text += delimiter + 'cw';
             }
+            text += 'sf' + delimiter;
         }
         text += '\n';
 
@@ -274,6 +276,7 @@
                 text += (data[id][i].len    || 1)  + delimiter;
                 text += (data[id][i].factor || 1)  + delimiter;
                 text += (data[id][i].offset || 0)  + delimiter;
+                text += (data[id][i].formula || "")  + delimiter;
             }
 
             text += (data[id][i].role || '') + delimiter;
@@ -285,6 +288,7 @@
                 if (!data.params.slave) {
                     text += (data[id][i].cw   ? 'true' : 'false') + delimiter;
                 }
+                text += (data[id][i].isScaleFactor   ? 'true' : 'false') + delimiter;
             }
             text += '\n';
         }
@@ -312,7 +316,7 @@
         var isAliases = $('#modbus_showAliases').prop('checked');
         var mapping;
         if (id !== 'coils' && id !== 'disInputs') {
-            mapping = ['deviceId', 'address', 'name', 'description', 'unit', 'type', 'len', 'factor', 'offset', 'role', 'room'];
+            mapping = ['deviceId', 'address', 'name', 'description', 'unit', 'type', 'len', 'factor', 'offset', 'role', 'room','formula','isScaleFactor'];
         } else {
             mapping = ['deviceId', 'address', 'name', 'description', 'role', 'room'];
         }
@@ -348,6 +352,8 @@
                     obj.factor = parseFloat(val) || 1;
                 } else if (mapping[m] === 'offset') {
                     obj.offset = parseFloat(val) || 0;
+                } else if (mapping[m] === 'formula') {
+                    obj.formula = val || "";
                 } else if (mapping[m] === 'len') {
                     obj.len = parseInt(val, 10) || 1;
                 } else if (mapping[m] === 'poll') {
@@ -359,6 +365,9 @@
                 } else if (mapping[m] === 'cw') {
                     obj[mapping[m]] = val || '';
                     obj.cw = (obj.cw.toLowerCase() === 'true' || obj.cw === '1' || obj.cw === '+');
+                } else if (mapping[m] === 'isScaleFactor') {
+                    obj[mapping[m]] = val || '';
+                    obj.isScaleFactor = (obj.isScaleFactor.toLowerCase() === 'true' || obj.isScaleFactor === '1' || obj.isScaleFactor === '+');
                 } else {
                     obj[mapping[m]] = val || '';
                 }
@@ -491,20 +500,22 @@
                     }
                 }
                 var fields = [
-                    {name: '_address'   , title:  _('Address'),       type: 'text',       width: '110px', sorter: 'number'},
+                    {name: '_address'   , title:  _('Address'),       type: 'text',       width: '80px', sorter: 'number'},
                     {name: 'deviceId'   , title:  _('deviceId'),      type: 'text',       width: '60px',  sorter: 'number'},
                     {name: 'name'       , title:  _('Name'),          type: 'text',       width: '*'},
                     {name: 'description', title:  _('Description'),   type: 'text',       width: '*'},
                     {name: 'unit'       , title:  _('Unit'),          type: 'text',       width: '50px'},
-                    {name: 'type'       , title:  _('Type'),          type: 'select',     width: '200px', items: typeItems,  valueField: 'value', textField: 'text'},
+                    {name: 'type'       , title:  _('Type'),          type: 'select',     width: '150px', items: typeItems,  valueField: 'value', textField: 'text'},
                     {name: 'len'        , title:  _('Length'),        type: 'text',       width: '50px'},
                     {name: 'factor'     , title:  _('Factor'),        type: 'text',       width: '50px'},
                     {name: 'offset'     , title:  _('Offset'),        type: 'text',       width: '50px'},
-                    {name: 'role'       , title:  _('Role'),          type: 'select',     width: '100px', items: roleItems,  valueField: 'value', textField: 'text'},
-                    {name: 'room'       , title:  _('Room'),          type: 'select',     width: '100px', items: roomsItems, valueField: 'value', textField: 'text'},
-                    {name: 'poll'       , title:  _('poll'),          type: 'checkbox',   width: '35px'},
-                    {name: 'wp'         , title:  _('WP'),            type: 'checkbox',   width: '35px'},
-                    {name: 'cw'         , title:  _('CW'),            type: 'checkbox',   width: '35px'},
+                    {name: 'formula'     , title:  _('formula'),      type: 'text',       width: '100px'},
+                    {name: 'role'       , title:  _('Role'),          type: 'select',     width: '70px', items: roleItems,  valueField: 'value', textField: 'text'},
+                    {name: 'room'       , title:  _('Room'),          type: 'select',     width: '70px', items: roomsItems, valueField: 'value', textField: 'text'},
+                    {name: 'poll'       , title:  _('poll'),          type: 'checkbox',   width: '30px'},
+                    {name: 'wp'         , title:  _('WP'),            type: 'checkbox',   width: '30px'},
+                    {name: 'cw'         , title:  _('CW'),            type: 'checkbox',   width: '30px'},
+                    {name: 'isScaleFactor', title:  _('SF'),          type: 'checkbox',   width: '30px'},
                     {                                                 type: 'control',    width: '80px'}
                 ];
                 if (_id === 'modbus_disInputs' || _id === 'modbus_inputRegs') {
@@ -610,6 +621,10 @@
                                 obj.item.offset = '';
                                 changed = true;
                             }
+                            if (obj.item.formula !== '') {
+                                obj.item.formula = '';
+                                changed = true;
+                            }
 
                             obj.item.len = parseInt(obj.item.len, 10) || 0;
                             if (!obj.item.len) {
@@ -667,6 +682,8 @@
                             obj.item.factor   = data[id][data[id].length - 1].factor;
                             obj.item.offset   = data[id][data[id].length - 1].offset;
                             obj.item.deviceId = data[id][data[id].length - 1].deviceId;
+                            obj.item.isScaleFactor = data[id][data[id].length - 1].isScaleFactor;
+                            obj.item.formula = data[id][data[id].length - 1].formula;
 
                             var len;
                             var defaultDeviceId = parseInt($('#modbus_deviceId').val(), 10) || 1;
@@ -753,6 +770,9 @@
                         } else
                         if ($(this).text() === _('CW')) {
                             $(this).attr('title', _('Cyclic write'));
+                        }
+                        if ($(this).text() === _('SF')) {
+                            $(this).attr('title', _('Store this value as scaling factor'));
                         }
                     });
                 }, 1000);

--- a/admin/words.js
+++ b/admin/words.js
@@ -152,5 +152,29 @@ systemDictionary = {
         "es": "preservar puntos en ID:",
         "pl": "zachowaj kropki w ID:",
         "zh-cn": "保留ID中的点："
+    },
+    "SF:": {
+        "en": "SF",
+        "de": "SF",
+        "ru": "SF",
+        "pt": "SF",
+        "nl": "",
+        "fr": "SF",
+        "it": "SF",
+        "es": "SF",
+        "pl": "SF",
+        "zh-cn": "SF"
+    },
+    "formula:": {
+        "en": "formula",
+        "de": "Formel",
+        "ru": "formula",
+        "pt": "formula",
+        "nl": "formula",
+        "fr": "formula",
+        "it": "formula",
+        "es": "formula",
+        "pl": "formula",
+        "zh-cn": "formula"
     }
 };

--- a/lib/master.js
+++ b/lib/master.js
@@ -1,6 +1,7 @@
 'use strict';
 const common = require('./common.js');
 const Modbus = require('./jsmodbus');
+var scaleFactors = {};
 // expected
 // let options =  {
 //     config: {
@@ -149,12 +150,17 @@ function Master(options, adapter) {
         if (block >= regs.blocks.length) {
             return callback();
         }
-
         const regBlock = regs.blocks[block];
 
         if (regBlock.startIndex === regBlock.endIndex) {
             regBlock.endIndex++;
         }
+        if(!scaleFactors[regs.deviceId]){
+            adapter.log.debug("Initialization of scalefactors done!");
+            scaleFactors[regs.deviceId] = {};
+        }
+
+        let sf = scaleFactors[regs.deviceId];
 
         adapter.log.debug(`Poll ${regType} DevID(${regs.deviceId}) address ${regBlock.start} - ${regBlock.count} bytes`);
         if (modbusClient) {
@@ -165,8 +171,26 @@ function Master(options, adapter) {
                             let id = regs.config[n].id;
                             let val = common.extractValue(regs.config[n].type, regs.config[n].len, response.payload, regs.config[n].address - regBlock.start);
                             if ((regs.config[n].type !== 'string') && (regs.config[n].type !== 'stringle')) {
-                                val = val * regs.config[n].factor + regs.config[n].offset;
-                                val = Math.round(val * options.config.round) / options.config.round;
+                                if(regs.config[n].hasOwnProperty('formula') && regs.config[n].formula !== ""){
+                                    var x = val;
+                                    adapter.log.debug("Input Value = " + x);
+                                    adapter.log.debug("Formula = " + regs.config[n].formula);
+                                    try{
+                                        // calculate value from formula or report an error
+                                        val = eval(regs.config[n].formula);
+                                    }catch{
+                                        adapter.log.warn("Calculation: eval("+regs.config[n].formula+") not possible: ")
+                                    }
+                                }else{
+                                    val = val * regs.config[n].factor + regs.config[n].offset;
+                                    val = Math.round(val * options.config.round) / options.config.round;
+                                }
+                                if(regs.config[n].hasOwnProperty('isScaleFactor') && regs.config[n].isScaleFactor){
+                                    scaleFactors[regs.deviceId.toString()][regs.config[n].address.toString()] = val;
+                                    sf[regs.config[n].address.toString()] = val;
+                                    adapter.log.debug("Scale factor value stored from address " + regs.config[n].address + " = " + sf[regs.config[n].address.toString()]);
+                                }
+                                    
                             }
                             if (options.config.alwaysUpdate || ackObjects[id] === undefined || ackObjects[id].val !== val) {
                                 ackObjects[id] = {val: val};

--- a/lib/master.js
+++ b/lib/master.js
@@ -178,6 +178,7 @@ function Master(options, adapter) {
                                     try{
                                         // calculate value from formula or report an error
                                         val = eval(regs.config[n].formula);
+                                        val = Math.round(val * options.config.round) / options.config.round;
                                     }catch{
                                         adapter.log.warn("Calculation: eval("+regs.config[n].formula+") not possible: ")
                                     }

--- a/lib/master.js
+++ b/lib/master.js
@@ -289,7 +289,7 @@ function Master(options, adapter) {
         } else {
             let currentPollTime = (new Date()).valueOf() - startTime;
 
-            if (pollTime !== null && pollTime !== undefined) {
+            if (pollTime !== undefined) {
                 if (Math.abs(pollTime - currentPollTime) > 100) {
                     pollTime = currentPollTime;
                     adapter.setState('info.pollTime', currentPollTime, true);

--- a/lib/master.js
+++ b/lib/master.js
@@ -185,7 +185,7 @@ function Master(options, adapter) {
                                     val = val * regs.config[n].factor + regs.config[n].offset;
                                     val = Math.round(val * options.config.round) / options.config.round;
                                 }
-                                if(regs.config[n].hasOwnProperty('isScaleFactor') && regs.config[n].isScaleFactor){
+                                if(regs.config[n].hasOwnProperty('isScale') && regs.config[n].isScale){
                                     scaleFactors[regs.deviceId.toString()][regs.config[n].address.toString()] = val;
                                     sf[regs.config[n].address.toString()] = val;
                                     adapter.log.debug("Scale factor value stored from address " + regs.config[n].address + " = " + sf[regs.config[n].address.toString()]);


### PR DESCRIPTION
#80 
Nun können Formeln eingesetzt werden und auch dynamische Skalierungsfaktoren. Die Hilfe sollte dazu noch angepasst werden
Formeln: Diese werden per eval() ausgewertet. Somit können alle gängigen Funktionen verwendet werden. Insbesondere die Math Funktionen. Die Formel muss korrekter Javascript syntax entsprechen somit auch case sensitiv!. Hierbei ist immer "x" der gelesene Wert von Modbus. Z.b. "x*Math.pow(10,sf['40065']);". Sollte eine Formel nicht ausgewertet werden können so wird dies als Warning im log ausgegeben

Skalierungsfaktoren: Damit ein dynamischer Faktor verwendbar ist, muss dieser zuerst mit dem flag "SF" markiert werden. Dann wird der Wert in eine Variable mit dem Namen sf['Modbus adresse'] gespeichert. Diese Variable kann dann in der Formel z.b. wie folgt verwendet werden "x * sf['40065']";