### PR TITLE
fix reconnect

### DIFF
--- a/lib/jsmodbus/transports/modbus-client-serial.js
+++ b/lib/jsmodbus/transports/modbus-client-serial.js
@@ -14,36 +14,44 @@ module.exports = stampit()
 
         let init = () => {
             this.setState('init');
-            let serial = this.options.serial;
-
-            if (!serial.portName) {
-                throw new Error('No portname.');
-            }
-
-            serial.baudRate = serial.baudRate || 9600; // the most are working with 9600
-            serial.dataBits = serial.dataBits || 8;
-            serial.stopBits = serial.stopBits || 1;
-            serial.parity   = serial.parity   || 'none';
-            // TODO: flowControl - ['xon', 'xoff', 'xany', 'rtscts']
-
-            // TODO: settings - ['brk', 'cts', 'dtr', 'dts', 'rts']
-
-            this.log.debug(`connect to serial ${serial.portName} with ${serial.baudRate}`);
-
-            serialport = new SerialPort({
-                path:       serial.portName,
-                baudRate:   serial.baudRate,
-                parity:     serial.parity,
-                dataBits:   serial.dataBits,
-                stopBits:   serial.stopBits
-            });
-
-            serialport.on('open',  onOpen);
-            serialport.on('close', onClose);
-            serialport.on('data',  onData);
-            serialport.on('error', onError);
+            connect();
 
             this.on('send', onSend);
+        };
+
+        let connect = () => {
+            this.setState('connect');
+
+            if (!serialport) {
+                let serial = this.options.serial;
+
+                if (!serial.portName) {
+                    throw new Error('No portname.');
+                }
+
+                serial.baudRate = serial.baudRate || 9600; // the most are working with 9600
+                serial.dataBits = serial.dataBits || 8;
+                serial.stopBits = serial.stopBits || 1;
+                serial.parity   = serial.parity   || 'none';
+                // TODO: flowControl - ['xon', 'xoff', 'xany', 'rtscts']
+
+                // TODO: settings - ['brk', 'cts', 'dtr', 'dts', 'rts']
+
+                this.log.debug(`connect to serial ${serial.portName} with ${serial.baudRate}`);
+
+                serialport = new SerialPort({
+                    path:       serial.portName,
+                    baudRate:   serial.baudRate,
+                    parity:     serial.parity,
+                    dataBits:   serial.dataBits,
+                    stopBits:   serial.stopBits
+                });
+
+                serialport.on('open',  onOpen);
+                serialport.on('close', onClose);
+                serialport.on('data',  onData);
+                serialport.on('error', onError);
+            }
         };
 
         let onOpen = () => {
@@ -139,17 +147,13 @@ module.exports = stampit()
             let crc16 = crc.crc16modbus(buf);
             pkt = pkt.word16le(crc16).buffer();
 
-            if (!serialport) {
-                init();
-            }
+            connect();
 
             serialport.write(pkt, err => err && this.emit('error', err));
         };
 
         this.connect = () => {
-            if (!serialport) {
-                init();
-            }
+            connect();
         };
 
         this.close = () => {


### PR DESCRIPTION
Prevent multiple onSend event handlers on reconnect after error.

Without this patch, on every reconnect a "this.on('send', onSend);" will be called. So, after a reconnect if an error occurs, there two event listeners are listens.
I move the connect functionality to a separate function, and call this and not the init() function for reconnects.